### PR TITLE
feat: allow uploading exercise videos from admin

### DIFF
--- a/frontend/src/services/exerciseService.ts
+++ b/frontend/src/services/exerciseService.ts
@@ -82,4 +82,36 @@ export const exerciseService = {
   async deleteExercise(id: number): Promise<void> {
     await exerciseApi.delete(`/api/exercises/${id}`)
   },
+
+  async uploadExerciseVideo(id: number, file: File): Promise<Exercise> {
+    const formData = new FormData()
+    formData.append('video', file)
+
+    const response = await exerciseApi.post<ApiResponse<Exercise>>(
+      `/api/exercises/${id}/video`,
+      formData,
+      {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      }
+    )
+
+    return response.data.data
+  },
+
+  async deleteExerciseVideo(id: number): Promise<void> {
+    await exerciseApi.delete(`/api/exercises/${id}/video`)
+  },
+
+  getExerciseVideoUrl(videoPath?: string | null): string | null {
+    if (!videoPath) {
+      return null
+    }
+
+    if (/^https?:\/\//i.test(videoPath)) {
+      return videoPath
+    }
+
+    const normalizedPath = videoPath.startsWith('/') ? videoPath : `/${videoPath}`
+    return `${window.location.origin}${normalizedPath}`
+  },
 }


### PR DESCRIPTION
## Summary
- add exercise service helpers for uploading, deleting and resolving video URLs
- extend the admin exercise form with video file selection, upload handling and UI feedback
- ensure exercise listings open the resolved video URL returned by the API

## Testing
- npm run lint *(fails: existing repository lint errors about React being in scope and multiple any types)*

------
https://chatgpt.com/codex/tasks/task_e_68e540a6b3d883308b81842d4cee6f14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Upload a video when creating or editing an exercise; upload starts after saving and completes before finishing the form.
  - Inline progress and status indicators (“Subiendo video…”, “Procesando el video…”), with the submit button disabled during upload.
  - Exercise pages now render video links using a fully resolved URL.

- Bug Fixes
  - Clearer error messages that distinguish between saving failures and video upload issues.
  - Form resets and edit flows now clear any previously selected video files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->