### PR TITLE
Allow workout video modal to load exercise assets

### DIFF
--- a/frontend/src/pages/WorkoutStartPage.tsx
+++ b/frontend/src/pages/WorkoutStartPage.tsx
@@ -1,6 +1,17 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { ArrowLeft, CheckCircle, Pause, Play, Plus, RotateCcw, Save, Timer, Trash2 } from 'lucide-react'
+import {
+  ArrowLeft,
+  CheckCircle,
+  Pause,
+  Play,
+  PlayCircle,
+  Plus,
+  RotateCcw,
+  Save,
+  Timer,
+  Trash2
+} from 'lucide-react'
 import LoadingSpinner from '../components/LoadingSpinner'
 import ErrorMessage from '../components/ErrorMessage'
 import VideoModal from '../components/VideoModal'
@@ -150,6 +161,18 @@ const WorkoutStartPage: React.FC = () => {
   const handleTimerReset = () => {
     setIsTimerRunning(false)
     setTimerSeconds(0)
+  }
+
+  const handleOpenVideo = (exercise: ExerciseWorkoutForm) => {
+    setVideoModalData({
+      name: exercise.exerciseName,
+      videoPath: exercise.exerciseVideoPath ?? '',
+      description: exercise.exerciseDescription
+    })
+  }
+
+  const handleCloseVideo = () => {
+    setVideoModalData(null)
   }
 
   const handleWorkoutComplete = () => {
@@ -466,9 +489,9 @@ const WorkoutStartPage: React.FC = () => {
             <form onSubmit={handleSubmit} className="space-y-6">
               {exercises.map((exercise, exerciseIndex) => (
                 <div key={exercise.exerciseId} className="bg-white rounded-lg shadow-md p-6">
-                  <div className="flex items-start justify-between mb-4">
-                    <div>
-                      <h2 className="text-xl font-semibold text-gray-900">{exercise.exerciseName}</h2>
+                  <div className="flex items-start justify-between mb-4 gap-4">
+                    <div className="min-w-0">
+                      <h2 className="text-xl font-semibold text-gray-900 truncate">{exercise.exerciseName}</h2>
                       <div className="text-sm text-gray-500 mt-1 space-x-3">
                         {exercise.targetRange && <span>Objetivo: {exercise.targetRange}</span>}
                         <span>
@@ -476,15 +499,30 @@ const WorkoutStartPage: React.FC = () => {
                           <span className="capitalize">{exercises[exerciseIndex].sets[0]?.technique ?? 'normal'}</span>
                         </span>
                       </div>
+                      {exercise.exerciseDescription && (
+                        <p className="mt-2 text-sm text-gray-600 break-words">{exercise.exerciseDescription}</p>
+                      )}
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => handleAddSet(exerciseIndex)}
-                      className="btn-secondary flex items-center text-sm"
-                    >
-                      <Plus className="h-4 w-4 mr-1" />
-                      Añadir serie
-                    </button>
+                    <div className="flex flex-col sm:flex-row sm:items-center gap-2 shrink-0">
+                      {(exercise.exerciseVideoPath || exercise.exerciseDescription) && (
+                        <button
+                          type="button"
+                          onClick={() => handleOpenVideo(exercise)}
+                          className="btn-secondary flex items-center text-sm"
+                        >
+                          <PlayCircle className="h-4 w-4 mr-1" />
+                          Ver guía
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => handleAddSet(exerciseIndex)}
+                        className="btn-secondary flex items-center text-sm"
+                      >
+                        <Plus className="h-4 w-4 mr-1" />
+                        Añadir serie
+                      </button>
+                    </div>
                   </div>
 
                     <div className="overflow-x-auto -mx-4 sm:mx-0">

--- a/services/exercise-service/src/server.js
+++ b/services/exercise-service/src/server.js
@@ -12,7 +12,11 @@ const app = express()
 const PORT = process.env.PORT || 3002
 
 // Security middleware
-app.use(helmet())
+app.use(
+  helmet({
+    crossOriginResourcePolicy: { policy: 'cross-origin' }
+  })
+)
 app.use(cors({
   origin: [
     'http://localhost:5173',


### PR DESCRIPTION
## Summary
- configure the exercise service helmet setup to allow cross-origin resource embedding so the SPA can stream uploaded videos

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68e55644320883309507d6e531eedfbb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-exercise video guidance with a modal showing name, description, and video when available.
  - Introduced a “Ver guía” button on each exercise; data clears on close.
- Style
  - Updated exercise row layout: single-line truncated titles, improved spacing/alignment, description shown beneath target ranges, and a consolidated actions area with “Ver guía” and “Añadir serie”.
- Bug Fixes
  - Improved compatibility for loading/playing guide videos from cross-origin sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->